### PR TITLE
Remove duplicates when two pattern matches the same event

### DIFF
--- a/js/communities/eventsRepository.js
+++ b/js/communities/eventsRepository.js
@@ -3,6 +3,7 @@ define(['./module'], function(app) {
 
     var mapEvents = function(googleEvent) {
         return {
+            id: googleEvent.id,
             title: googleEvent.summary,
             description: googleEvent.description,
             location: googleEvent.location,
@@ -10,6 +11,19 @@ define(['./module'], function(app) {
             endDate: Date.parse(googleEvent.end.dateTime),
             url: googleEvent.htmlLink
         }
+    };
+
+    var removeDuplicates = function(events) {
+      var tmpEvents = {};
+      for (var i = 0, n = events.length; i < n; i++) {
+        tmpEvents[events[i].id] = events[i];
+      }
+      var i = 0;
+      events = [];
+      for(var id in tmpEvents) {
+        events[i++] = tmpEvents[id];
+      }
+      return events;
     };
 
     var eventsRepository = function($http, $q) {
@@ -32,7 +46,7 @@ define(['./module'], function(app) {
                 for(var index = 0; index < result.length; index++) {
                     events = events.concat(result[index].data.items.map(mapEvents));
                 }
-                deferred.resolve(events);
+                deferred.resolve(removeDuplicates(events));
             });
 
             return deferred.promise;


### PR DESCRIPTION
If a community has patterns configured like this :

```
"patternsGoogleCalendar": ["Apéro PHP", "AFUP"],
```

and if an event has a title "Apéro PHP" and a link
in the description that contains "afup" (for exemple
a link to "lyon.afup.org",

then then event is displayed twice (because the event
is found is both requests to google calendar).

To avoid that we remove duplicates from the event list,
based on the google calendar id.

Before: 
![before](https://cloud.githubusercontent.com/assets/320372/4411819/8fafa1e8-44f2-11e4-82d6-106ac6483378.png)

After:
![after](https://cloud.githubusercontent.com/assets/320372/4411822/95d6a4d6-44f2-11e4-913e-2af7b8986c73.png)
