### PR TITLE
Add TupperVim Lyon

### DIFF
--- a/data/TupperVim.json
+++ b/data/TupperVim.json
@@ -1,0 +1,7 @@
+{
+    "patternsGoogleCalendar": ["TupperVim"],
+    "socialLinks": [
+        { "icon": "link", "tooltip": "Web site", "url": "http://tuppervim.org" },
+        { "icon": "twitter", "tooltip": "Twitter", "url": "https://twitter.com/tupperVim" }
+    ]
+}

--- a/data/communities.json
+++ b/data/communities.json
@@ -147,5 +147,11 @@
         "name": "Software Craftsmanship Lyon",
         "shortDescription": "La communauté Software Craftsmanship Lyon réunit les développeurs, sans sexisme, élitisme ni langage ou techno obligatoire.",
         "tags": ["Craftsmanship", "artisan", "Coding Dojo"]
+    },
+    {
+        "key": "TupperVim",
+        "name": "TupperVim",
+        "shortDescription": "Les Tuppervim sont des évènements où l’on partage des connaissances et des astuces à propos de Vim.",
+        "tags": ["TupperVim", "vim", "vi"]
     }
 ]

--- a/imgs/TupperVim.svg
+++ b/imgs/TupperVim.svg
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="560"
+   height="230"
+   id="svg3894"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="TupperVimlogo.svg">
+  <defs
+     id="defs3896" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="290.32875"
+     inkscape:cy="218.49762"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1854"
+     inkscape:window-height="804"
+     inkscape:window-x="30"
+     inkscape:window-y="120"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata3899">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-822.36218)">
+    <path
+       id="path2836"
+       d="m 453.34983,842.40997 -94.79151,94.91892 94.39654,94.52341 94.7915,-94.91891 -94.39653,-94.52342 z"
+       style="fill:#019833;fill-opacity:1;stroke:#000000;stroke-width:0.55332196px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path2838"
+       d="m 452.95486,842.80548 0,-8.30542 -103.08574,103.22431 8.6892,0 94.39654,-94.91889 z"
+       style="fill:#66fe98;fill-opacity:1;stroke:#000000;stroke-width:0.55332196px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#45fe02;fill-opacity:1;stroke:#000000;stroke-width:0.55332196px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 452.71789,842.80548 0,-8.30542 103.08576,103.22431 -8.68922,0 -94.39654,-94.91889 z"
+       id="path2840"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#017d17;fill-opacity:1;stroke:#000000;stroke-width:0.55332196px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 452.95486,1032.406 0,8.3054 -103.08574,-103.22431 8.6892,0 94.39654,94.91891 z"
+       id="path2842"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path3650"
+       d="m 368.99322,844.98321 66.46918,0 4.04958,4.05503 0,12.44476 -3.21175,3.9152 -7.26134,0 0,61.80431 62.55921,-61.80431 -10.33344,0 -3.63067,-3.9152 0,-13.14391 3.35139,-3.07622 67.307,0 3.35139,3.35589 0,12.30491 -152.20877,156.32853 -17.3155,0 -5.01204,-2.8975 0,-149.51581 -8.3935,0 -3.07211,-3.07624 0,-13.14389 3.35137,-3.63555 z"
+       style="fill:none;stroke:#000000;stroke-width:11.06643963;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path2844"
+       d="m 452.71789,1032.406 0,8.3054 103.08576,-103.22431 -8.68922,0 -94.39654,94.91891 z"
+       style="fill:#005d04;fill-opacity:1;stroke:#000000;stroke-width:0.55332196px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:3.31993151;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="M 452.67672,833.73443 349.20324,937.34698 452.24558,1040.5278 555.71908,936.91528 452.67672,833.73443 z"
+       id="path2846"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path3640"
+       d="m 436.16885,851.30862 3.75217,-1.97748 -3.85091,-3.85608 -67.04523,0 -3.40658,3.41114 0,12.90304 3.77686,3.78193 1.80203,-3.78193 -2.3698,-2.37296 0,-9.0964 1.77735,-1.58198 63.98426,0 1.57985,2.57072 z"
+       style="fill:#fefefe;fill-opacity:1;stroke:#000000;stroke-width:0.55332196px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       transform="matrix(0.55295046,0,0,0.55369364,25.208179,643.74985)"
+       d="m 828.9375,369.5 -4.28125,4.28125 0,15.71875 3.75,3.75 19.8125,0 0,15.1875 -131.0625,132.84375 0,-147.84375 21.78125,0 4.46875,-4.46875 0,-15.90625 -4.125,-3.1875 -114.625,0 -3.75,3.75 0,16.25 3.8125,3.8125 19.9375,0 0,272.25 3.75,3.75 22.65625,0 274.65625,-283.40625 0,-12.5 -4.28125,-4.28125 -112.5,0 z"
+       id="path3632"
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xlink:href="#path3630"
+       inkscape:original="M 828.9375 369.5 L 824.65625 373.78125 L 824.65625 389.5 L 828.40625 393.25 L 848.21875 393.25 L 848.21875 408.4375 L 717.15625 541.28125 L 717.15625 393.4375 L 738.9375 393.4375 L 743.40625 388.96875 L 743.40625 373.0625 L 739.28125 369.875 L 624.65625 369.875 L 620.90625 373.625 L 620.90625 389.875 L 624.71875 393.6875 L 644.65625 393.6875 L 644.65625 665.9375 L 648.40625 669.6875 L 671.0625 669.6875 L 945.71875 386.28125 L 945.71875 373.78125 L 941.4375 369.5 L 828.9375 369.5 z "
+       inkscape:radius="0"
+       sodipodi:type="inkscape:offset"
+       inkscape:href="#path3630" />
+    <path
+       id="path3646"
+       d="m 381.56094,861.483 0,151.015 1.95496,2.2373 -1.53308,2.9258 -4.33183,-4.3241 0,-147.9388 z"
+       style="fill:#fefefe;fill-opacity:1;stroke:#000000;stroke-width:0.55332196px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       id="path3644"
+       d="m 370.72929,861.483 -1.11713,3.63554 8.09919,0 4.46852,-3.63554 -11.45058,0 z"
+       style="fill:#808080;fill-opacity:1;stroke:#000000;stroke-width:0.55332196px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cccccccccccccccccc"
+       id="path3638"
+       d="m 481.98476,865.56623 1.77734,-3.65833 -2.56727,-2.37298 0,-8.10765 2.96223,-2.96622 61.81197,0 2.36979,3.16397 3.35719,-2.37297 -3.45593,-3.4606 -66.45281,0 -3.30782,3.31228 0,13.00191 3.43125,3.23813 m -53.70284,62.43142 -6.4552,15.68386 72.87097,-73.16665 0,-8.7009 -66.41577,66.18369 z"
+       style="fill:#fefefe;fill-opacity:1;stroke:#000000;stroke-width:0.55332196px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccccccccccc"
+       id="path3642"
+       d="m 436.02094,850.85601 3.21176,-2.09743 0,12.72442 -3.70049,3.70546 -7.19151,0 0,62.71319 -6.56315,15.521 0,-81.93965 12.00914,0 2.23425,-1.81778 0,-8.80921 z"
+       style="fill:#808080;fill-opacity:1;stroke:#000000;stroke-width:0.55332196px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       transform="matrix(0.55295046,0,0,0.55369364,25.208179,643.74985)"
+       d="m 828.9375,369.5 -4.28125,4.28125 0,15.71875 3.75,3.75 19.8125,0 0,15.1875 -131.0625,132.84375 0,-147.84375 21.78125,0 4.46875,-4.46875 0,-15.90625 -4.125,-3.1875 -114.625,0 -3.75,3.75 0,16.25 3.8125,3.8125 19.9375,0 0,272.25 3.75,3.75 22.65625,0 274.65625,-283.40625 0,-12.5 -4.28125,-4.28125 -112.5,0 z"
+       inkscape:href="#path3620"
+       id="path3622"
+       style="fill:#cccccc;fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xlink:href="#path3620"
+       inkscape:original="M 828.9375 369.5 L 824.65625 373.78125 L 824.65625 389.5 L 828.40625 393.25 L 848.21875 393.25 L 848.21875 408.4375 L 717.15625 541.28125 L 717.15625 393.4375 L 738.9375 393.4375 L 743.40625 388.96875 L 743.40625 373.0625 L 739.28125 369.875 L 624.65625 369.875 L 620.90625 373.625 L 620.90625 389.875 L 624.71875 393.6875 L 644.65625 393.6875 L 644.65625 665.9375 L 648.40625 669.6875 L 671.0625 669.6875 L 945.71875 386.28125 L 945.71875 373.78125 L 941.4375 369.5 L 828.9375 369.5 z "
+       inkscape:radius="0"
+       sodipodi:type="inkscape:offset" />
+    <path
+       id="path3636"
+       d="m 548.33882,850.91312 3.37302,-1.95003 0,12.23291 -152.98766,156.5399 -16.24246,0 1.55182,-3.0877 12.44138,0 151.66642,-156.8139 z"
+       style="fill:#808080;fill-opacity:1;stroke:#000000;stroke-width:0.55332196px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       id="path3652"
+       d="m 494.32111,861.69274 -3.42121,3.56563 -8.93702,0 2.0946,-3.56563 c 0.0698,0 10.26363,0 10.26363,0 z"
+       style="fill:#808080;fill-opacity:1;stroke:#000000;stroke-width:0.55332196px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <g
+       transform="matrix(0.55295046,0,0,0.55369364,236.7809,639.88167)"
+       id="g3673">
+      <path
+         sodipodi:type="inkscape:offset"
+         inkscape:radius="1.2328869"
+         inkscape:original="M 400.03125 561.21875 L 394.71875 565.78125 L 389.40625 580.65625 L 393.46875 584.71875 L 409.875 584.71875 L 414.15625 580.40625 L 418.71875 564.75 L 415.1875 561.21875 L 400.03125 561.21875 z M 369.96875 603.15625 L 367.9375 611.21875 L 379.3125 611.21875 L 354.8125 681.1875 L 389.65625 681.1875 L 391.9375 673.84375 L 382.34375 673.84375 L 406.59375 603.15625 L 369.96875 603.15625 z M 480.84375 603.40625 L 473.25 612 L 460.625 612 L 452.5625 603.65625 L 425.03125 603.65625 L 422.5 611.21875 L 431.59375 611.21875 L 408.09375 680.4375 L 437.40625 680.4375 L 439.65625 673.84375 L 432.84375 673.84375 L 448.25 625.375 L 477.3125 625.375 L 460.125 680.4375 L 488.40625 680.4375 L 490.9375 674.375 L 484.125 674.375 L 499.78125 625.125 L 527.5625 625.125 L 510.125 680.4375 L 541.1875 680.4375 L 543.71875 673.84375 L 535.875 673.84375 L 555.09375 611.46875 L 549.28125 603.65625 L 527.0625 603.65625 L 519.71875 611.71875 L 506.34375 611.71875 L 498.75 603.40625 L 480.84375 603.40625 z "
+         style="fill:#cccccc;fill-opacity:1;stroke:#000000;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none"
+         id="path3671"
+         d="m 399.78125,560 a 1.2330102,1.2330102 0 0 0 -0.5625,0.28125 l -5.3125,4.5625 A 1.2330102,1.2330102 0 0 0 393.5625,565.375 L 388.25,580.25 a 1.2330102,1.2330102 0 0 0 0.28125,1.28125 l 4.0625,4.0625 a 1.2330102,1.2330102 0 0 0 0.875,0.34375 l 16.40625,0 a 1.2330102,1.2330102 0 0 0 0.875,-0.34375 l 4.28125,-4.3125 a 1.2330102,1.2330102 0 0 0 0.3125,-0.53125 l 4.5625,-15.65625 a 1.2330102,1.2330102 0 0 0 -0.3125,-1.21875 l -3.53125,-3.53125 A 1.2330102,1.2330102 0 0 0 415.1875,560 l -15.15625,0 a 1.2330102,1.2330102 0 0 0 -0.25,0 z m -30.0625,41.9375 a 1.2330102,1.2330102 0 0 0 -0.9375,0.90625 l -2.03125,8.0625 a 1.2330102,1.2330102 0 0 0 1.1875,1.53125 l 9.65625,0 -23.9375,68.34375 a 1.2330102,1.2330102 0 0 0 1.15625,1.625 l 34.84375,0 a 1.2330102,1.2330102 0 0 0 1.1875,-0.84375 l 2.28125,-7.34375 a 1.2330102,1.2330102 0 0 0 -1.1875,-1.59375 l -7.875,0 23.6875,-69.0625 a 1.2330102,1.2330102 0 0 0 -1.15625,-1.625 l -36.625,0 a 1.2330102,1.2330102 0 0 0 -0.25,0 z m 110.875,0.25 a 1.2330102,1.2330102 0 0 0 -0.6875,0.40625 l -7.25,8.1875 -11.53125,0 -7.6875,-7.96875 a 1.2330102,1.2330102 0 0 0 -0.875,-0.375 l -27.53125,0 A 1.2330102,1.2330102 0 0 0 423.875,603.25 l -2.53125,7.5625 a 1.2330102,1.2330102 0 0 0 1.15625,1.625 l 7.375,0 -22.9375,67.59375 a 1.2330102,1.2330102 0 0 0 1.15625,1.625 l 29.3125,0 a 1.2330102,1.2330102 0 0 0 1.15625,-0.8125 l 2.25,-6.59375 a 1.2330102,1.2330102 0 0 0 -1.15625,-1.625 l -5.125,0 14.625,-46.03125 26.46875,0 -16.6875,53.46875 a 1.2330102,1.2330102 0 0 0 1.1875,1.59375 l 28.28125,0 a 1.2330102,1.2330102 0 0 0 1.125,-0.75 l 2.53125,-6.0625 a 1.2330102,1.2330102 0 0 0 -1.125,-1.6875 l -5.125,0 14.875,-46.8125 25.1875,0 -16.9375,53.71875 a 1.2330102,1.2330102 0 0 0 1.1875,1.59375 l 31.0625,0 a 1.2330102,1.2330102 0 0 0 1.15625,-0.78125 l 2.53125,-6.59375 a 1.2330102,1.2330102 0 0 0 -1.15625,-1.65625 l -6.15625,0 18.71875,-60.78125 a 1.2330102,1.2330102 0 0 0 -0.1875,-1.125 l -5.8125,-7.8125 a 1.2330102,1.2330102 0 0 0 -1,-0.46875 l -22.21875,0 a 1.2330102,1.2330102 0 0 0 -0.90625,0.375 l -7,7.6875 -12.25,0 -7.25,-7.9375 a 1.2330102,1.2330102 0 0 0 -0.90625,-0.375 l -17.90625,0 a 1.2330102,1.2330102 0 0 0 -0.25,0 z" />
+      <path
+         d="m 400.03125,561.21875 -5.3125,4.5625 -5.3125,14.875 4.0625,4.0625 16.40625,0 4.28125,-4.3125 4.5625,-15.65625 -3.53125,-3.53125 -15.15625,0 z m -30.0625,41.9375 -2.03125,8.0625 11.375,0 -24.5,69.96875 34.84375,0 2.28125,-7.34375 -9.59375,0 24.25,-70.6875 -36.625,0 z m 110.875,0.25 L 473.25,612 l -12.625,0 -8.0625,-8.34375 -27.53125,0 -2.53125,7.5625 9.09375,0 -23.5,69.21875 29.3125,0 2.25,-6.59375 -6.8125,0 15.40625,-48.46875 29.0625,0 -17.1875,55.0625 28.28125,0 2.53125,-6.0625 -6.8125,0 15.65625,-49.25 27.78125,0 -17.4375,55.3125 31.0625,0 2.53125,-6.59375 -7.84375,0 19.21875,-62.375 -5.8125,-7.8125 -22.21875,0 -7.34375,8.0625 -13.375,0 -7.59375,-8.3125 -17.90625,0 z"
+         id="path3665"
+         style="fill:#cccccc;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:original="M 400.03125 561.21875 L 394.71875 565.78125 L 389.40625 580.65625 L 393.46875 584.71875 L 409.875 584.71875 L 414.15625 580.40625 L 418.71875 564.75 L 415.1875 561.21875 L 400.03125 561.21875 z M 369.96875 603.15625 L 367.9375 611.21875 L 379.3125 611.21875 L 354.8125 681.1875 L 389.65625 681.1875 L 391.9375 673.84375 L 382.34375 673.84375 L 406.59375 603.15625 L 369.96875 603.15625 z M 480.84375 603.40625 L 473.25 612 L 460.625 612 L 452.5625 603.65625 L 425.03125 603.65625 L 422.5 611.21875 L 431.59375 611.21875 L 408.09375 680.4375 L 437.40625 680.4375 L 439.65625 673.84375 L 432.84375 673.84375 L 448.25 625.375 L 477.3125 625.375 L 460.125 680.4375 L 488.40625 680.4375 L 490.9375 674.375 L 484.125 674.375 L 499.78125 625.125 L 527.5625 625.125 L 510.125 680.4375 L 541.1875 680.4375 L 543.71875 673.84375 L 535.875 673.84375 L 555.09375 611.46875 L 549.28125 603.65625 L 527.0625 603.65625 L 519.71875 611.71875 L 506.34375 611.71875 L 498.75 603.40625 L 480.84375 603.40625 z "
+         inkscape:radius="0"
+         sodipodi:type="inkscape:offset" />
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-size:25.4434967px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-3.3949881"
+       y="1017.8347"
+       id="text3093"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3095"
+         x="-3.3949881"
+         y="1017.8347"
+         style="font-size:91.59658051000000967px;font-style:oblique;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;opacity:1;fill:#b3b3b3;stroke:#000000;stroke-width:3.11682772999999980;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;font-family:Verdana;-inkscape-font-specification:Verdana">Tupper</tspan></text>
+  </g>
+</svg>


### PR DESCRIPTION
Bonjour,

Les soirées [Tuppervim](http://tuppervim.org/) sont des évènements pour partager des trucs et astuces sur l'éditeur de texte Vim.

Des soirées TupperVim sont dores et déjà organisées sur Paris et Grenoble, et deux sessions ont déjà été organisées sur Lyon depuis le début de l'année avec une bonne audience (au moins une vingtaine de personne à chaque fois). Désormais avec l'[ALDIL](http://aldil.org/), ce sessions seront organisées à Lyon environ tous les 2 mois à l'Épitech, au 156 rue Paul Bert, Lyon 3ème. D'où le souhait d'inscrire l'évènement à votre calendrier.

Merci d'avance

PS : je vous avoue ne pas être sûr de ce que doit contenir la propriété "patternsGoogleCalendar" dans le fichier TupperVim.json. Prévenez-moi si je fais une bêtise :).

Florent
