### PR TITLE
fix community page for LyonJS

### DIFF
--- a/data/LyonJS.json
+++ b/data/LyonJS.json
@@ -4,6 +4,6 @@
         { "icon": "link", "tooltip": "Web site", "url": "http://lyonjs.org/"},
         { "icon": "twitter", "tooltip": "Twitter", "url": "https://twitter.com/LyonJS"},
         { "icon": "github", "tooltip": "Git Hub Organization", "url": "https://github.com/lyonjs"},
-         { "icon": "youtube-play", "tooltip": "Youtube channel", "url": "https://www.youtube.com/channel/UCGTVc5PnIgAUoA2D2_6nJLg"},
+        { "icon": "youtube-play", "tooltip": "Youtube channel", "url": "https://www.youtube.com/channel/UCGTVc5PnIgAUoA2D2_6nJLg"}
     ]
 }


### PR DESCRIPTION
il y avait une erreur sur la page, les événements n'étaient pas affichés : 

![capture du 2016-04-26 12 57 53](https://cloud.githubusercontent.com/assets/320372/14816099/56d0e046-0baf-11e6-85d5-417361582ccb.png)

Après suppression de la virgule de fin, les événements et liens sont bien affichés : 
![capture du 2016-04-26 12 58 07](https://cloud.githubusercontent.com/assets/320372/14816121/6b761a2a-0baf-11e6-9947-099ce0f8ae4d.png)
