### PR TITLE
Update website link

### DIFF
--- a/data/LyonDataScience.json
+++ b/data/LyonDataScience.json
@@ -1,7 +1,7 @@
 {
     "patternsGoogleCalendar": ["Lyon Data Science"],
     "socialLinks": [
-        { "icon": "link", "tooltip": "Web site", "url": "http://t.co/3F3ZHGYQp0"},
+        { "icon": "link", "tooltip": "Web site", "url": "http://www.lyondata.science"},
         { "icon": "twitter", "tooltip": "Twitter", "url": "https://twitter.com/LyonDataScience"},
         { "icon": "facebook", "tooltip": "Facebook", "url": "https://www.facebook.com/pages/Lyondatascience/503525249798412?ref=tn_tnmn"},
         { "icon": "github", "tooltip": "Git Hub Organization", "url": "https://github.com/lyondatascience"}


### PR DESCRIPTION
Lyon Data Science has a DNS domain :  lyondata.science update this value for the website link.
