### PR TITLE
don't trim whitespace in .astro files b/c spaces are meaningful in HTML

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,7 +15,7 @@ indent_size = 4
 [{*.json,*.yml,*.less}]
 indent_size = 2
 
-[*.md]
+[*.md,.astro]
 trim_trailing_whitespace = false
 
 [makefile]

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -25,8 +25,8 @@ import Layout from '../layouts/Layout.astro';
                             <span class="lth-card-icon"><i class="fa fa-handshake"></i></span>
                             <p class="lth-card-title">Rejoignez-nous !</p>
                             <h4><i class="fab fa-slack"></i> Sur Slack</h4>
-                            <p class="lth-card-text">Pour discuter avec les membres de nos communautés sur Slack,
-                                <a href="https://slack.lyontechhub.org/">inscrivez-vous</a> sur la page
+                            <p class="lth-card-text">Pour discuter avec les membres de nos communautés sur Slack, 
+                                <a href="https://slack.lyontechhub.org/">inscrivez-vous</a> sur la page 
                                 <a href="https://slack.lyontechhub.org/">https://slack.lyontechhub.org</a>.
                             </p>
                             <h4><i class="fa fa-calendar"></i> Évènements</h4>
@@ -51,7 +51,7 @@ import Layout from '../layouts/Layout.astro';
                             </p>
                             <ul class="lth-card-text lth-card-list">
                                 <li>Forkez <a href="https://github.com/lyontechhub/lyontechhub.github.io">le repository du projet</a>.
-                                    Pour plus d'informations sur les pull requests, consultez
+                                    Pour plus d'informations sur les pull requests, consultez 
                                     <a href="https://help.github.com/articles/using-pull-requests">l'aide de Github</a>.
                                 </li>
                                 <li>
@@ -77,8 +77,8 @@ import Layout from '../layouts/Layout.astro';
                 <p class="about-contact-title">Des questions ?</p>
                 <p class="about-contact-subtitle">Contactez-nous</p>
                 <div class="about-contact-links">
-                    <a href="https://x.com/LyonTechHub"><i class="fab fa-twitter"></i> @lyontechhub</a>
-                    <a href="mailto:contact@lyontechhub.org"><i class="fa fa-envelope"></i> contact@lyontechhub.org</a>
+                    <a href="https://x.com/LyonTechHub"><i class="fab fa-twitter"></i>@lyontechhub</a>
+                    <a href="mailto:contact@lyontechhub.org"><i class="fa fa-envelope"></i>contact@lyontechhub.org</a>
                 </div>
             </div>
         </div>

--- a/src/pages/calendar.astro
+++ b/src/pages/calendar.astro
@@ -12,7 +12,7 @@ import Layout from '../layouts/Layout.astro';
             <p class="subtitle">
               Venez rencontrer toutes ces communautés et leurs participants !
             </p>
-            <p><span class="icon is-medium"><i class="fa fa-calendar"></i></span>Ajouter le calendrier des nouveaux événements à vos calendriers
+            <p><span class="icon is-medium"><i class="fa fa-calendar"></i></span>Ajouter le calendrier des nouveaux événements à vos calendriers 
                 <a href="https://www.lyontechhub.org/Lyon-Tech-Hub-Calendar/calendar.ics">au format ical</a>.</p>
 
             <nav class="navbar is-justify-content-center calendar-header">


### PR DESCRIPTION
missing spaces between text node and link:
<p><img width="800" alt="image" src="https://github.com/user-attachments/assets/8cfa170d-764e-4ae7-8df7-5275bd27cb2b" />

edit: also removed those ugly underlined spaces because inline tags are hard
<img width="726" height="232" alt="image" src="https://github.com/user-attachments/assets/04438980-b6b8-45b9-92ed-cbf0e0ee55f9" />

